### PR TITLE
fix: add next price negativity check

### DIFF
--- a/x/halo/keeper/msg_server_aggregator.go
+++ b/x/halo/keeper/msg_server_aggregator.go
@@ -48,7 +48,7 @@ func (k aggregatorMsgServer) ReportBalance(goCtx context.Context, msg *aggregato
 	}
 	k.SetRound(ctx, id, round)
 
-	if msg.NextPrice.IsNegative() || msg.NextPrice.IsZero() || msg.NextPrice.LTE(answer) {
+	if !msg.NextPrice.IsPositive() || msg.NextPrice.LTE(answer) {
 		return nil, aggregator.ErrInvalidNextPrice
 	}
 	k.Keeper.SetNextPrice(ctx, msg.NextPrice)

--- a/x/halo/keeper/msg_server_aggregator.go
+++ b/x/halo/keeper/msg_server_aggregator.go
@@ -48,7 +48,7 @@ func (k aggregatorMsgServer) ReportBalance(goCtx context.Context, msg *aggregato
 	}
 	k.SetRound(ctx, id, round)
 
-	if msg.NextPrice.IsZero() || msg.NextPrice.LTE(answer) {
+	if msg.NextPrice.IsNegative() || msg.NextPrice.IsZero() || msg.NextPrice.LTE(answer) {
 		return nil, aggregator.ErrInvalidNextPrice
 	}
 	k.Keeper.SetNextPrice(ctx, msg.NextPrice)

--- a/x/halo/keeper/msg_server_aggregator_test.go
+++ b/x/halo/keeper/msg_server_aggregator_test.go
@@ -56,6 +56,18 @@ func TestReportBalance(t *testing.T) {
 	// ASSERT: The action should've failed due to identical round.
 	require.ErrorContains(t, err, aggregator.ErrAlreadyReported.Error())
 
+	// ACT: Attempt to report balance with a negative next price.
+	msg = aggregator.MsgReportBalance{
+		Signer:      owner.Address,
+		Principal:   utils.MustParseInt("4600092531"),
+		Interest:    utils.MustParseInt("658502"),
+		TotalSupply: utils.MustParseInt("44285046691709"),
+		NextPrice:   utils.MustParseInt("-1"),
+	}
+	_, err = server.ReportBalance(goCtx, &msg)
+	// ASSERT: The action should've failed due to invalid next price.
+	require.ErrorContains(t, err, aggregator.ErrInvalidNextPrice.Error())
+
 	// ACT: Attempt to report balance with invalid next price.
 	// https://etherscan.io/tx/0xe8154863cf89175c9ec361999ec7ddeebf7c29297ee62325f777067409071303
 	msg = aggregator.MsgReportBalance{


### PR DESCRIPTION
This PR ensure that the `NextPrice` in the `ReportBalance` is not negative.

Closes #1 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced validation for the next price input in the balance reporting functionality, ensuring that only positive values are accepted.
  
- **Bug Fixes**
	- Improved error handling for scenarios where a negative next price is provided, ensuring invalid inputs are correctly flagged.

- **Tests**
	- Added a new test case to verify the error handling for negative next price values, strengthening the testing suite's coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->