### PR TITLE
fix: ensure round existence

### DIFF
--- a/x/halo/keeper/keeper.go
+++ b/x/halo/keeper/keeper.go
@@ -1,10 +1,9 @@
 package keeper
 
 import (
+	sdkerrors "cosmossdk.io/errors"
 	"encoding/json"
 	"fmt"
-
-	sdkerrors "cosmossdk.io/errors"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -123,7 +122,10 @@ func (k *Keeper) mintCoins(ctx sdk.Context, recipient sdk.AccAddress, coins sdk.
 
 // depositFor is an internal helper function to deposit.
 func (k *Keeper) depositFor(ctx sdk.Context, signer sdk.AccAddress, recipient sdk.AccAddress, underlying sdk.Int) (amount sdk.Int, err error) {
-	round, _ := k.GetRound(ctx, k.GetLastRoundId(ctx))
+	round, found := k.GetRound(ctx, k.GetLastRoundId(ctx))
+	if !found {
+		return sdk.Int{}, fmt.Errorf("round %d not found", k.GetLastRoundId(ctx))
+	}
 	amount = underlying.QuoRaw(10000).MulRaw(10000)
 	amount = amount.MulRaw(100000000).Quo(round.Answer)
 
@@ -147,7 +149,10 @@ func (k *Keeper) depositFor(ctx sdk.Context, signer sdk.AccAddress, recipient sd
 
 // withdrawTo is an internal helper function to withdraw.
 func (k *Keeper) withdrawTo(ctx sdk.Context, signer sdk.AccAddress, recipient sdk.AccAddress, amount sdk.Int) (underlying sdk.Int, err error) {
-	round, _ := k.GetRound(ctx, k.GetLastRoundId(ctx))
+	round, found := k.GetRound(ctx, k.GetLastRoundId(ctx))
+	if !found {
+		return sdk.Int{}, fmt.Errorf("round %d not found", k.GetLastRoundId(ctx))
+	}
 	underlying = amount.Mul(round.Answer).QuoRaw(100000000)
 	underlying = underlying.QuoRaw(10000).MulRaw(10000)
 

--- a/x/halo/keeper/msg_server_test.go
+++ b/x/halo/keeper/msg_server_test.go
@@ -135,6 +135,15 @@ func TestDepositFor(t *testing.T) {
 	// ARRANGE: Assign the international feeder role to recipient.
 	k.SetUserRole(ctx, recipient.Bytes, entitlements.ROLE_INTERNATIONAL_FEEDER, true)
 
+	// ACT: Attempt to deposit for with non-existing round.
+	_, err = server.DepositFor(goCtx, &types.MsgDepositFor{
+		Signer:    user.Address,
+		Recipient: recipient.Address,
+		Amount:    amount,
+	})
+	// ASSERT: The action should've failed due to non-existing round.
+	require.ErrorContains(t, err, "round 0 not found")
+
 	// ARRANGE: Report Ethereum Round #229.
 	// https://etherscan.io/tx/0xcff68ffc6f79afadf835f559f8a51ed7092bc679d2a4f34cd153ef321d6bc8ec
 	k.SetRound(ctx, 229, aggregator.RoundData{
@@ -390,6 +399,17 @@ func TestWithdrawTo(t *testing.T) {
 
 	// ARRANGE: Set user withdrawal nonce in state.
 	k.SetNonce(ctx, recipient.Bytes, 10)
+
+	// ACT: Attempt to withdraw to with non-existing last round.
+	_, err = server.WithdrawTo(goCtx, &types.MsgWithdrawTo{
+		Signer:    user.Address,
+		Recipient: recipient.Address,
+		Amount:    amount,
+		Signature: signature,
+	})
+	// ASSERT: The action should've failed due to non-existing last round.
+	require.ErrorContains(t, err, "round 0 not found")
+
 	// ARRANGE: Report Ethereum Round #139.
 	// https://etherscan.io/tx/0x9095266d81856a28b80c4500228ab994197652fc4ad1c05cd4345d1454fccfd7
 	k.SetRound(ctx, 139, aggregator.RoundData{
@@ -400,6 +420,9 @@ func TestWithdrawTo(t *testing.T) {
 		UpdatedAt: 1706011979,
 	})
 	k.SetLastRoundId(ctx, 139)
+
+	// ARRANGE: Set user withdrawal nonce in state.
+	k.SetNonce(ctx, recipient.Bytes, 10)
 
 	// ACT: Attempt to withdraw to with insufficient funds.
 	_, err = server.WithdrawTo(goCtx, &types.MsgWithdrawTo{


### PR DESCRIPTION
This PR ensure that an existing Round is found on `depositFor` and `withdrawTo` functions.

Closes #2 