### PR TITLE
fix: ensure state compatibility with v1

### DIFF
--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -46,7 +46,7 @@ type Keeper struct {
 	EntitlementsOwner  collections.Item[string]
 	Paused             collections.Item[bool]
 	PublicCapabilities collections.Map[string, bool]
-	RoleCapabilities   collections.Map[collections.Pair[string, uint64], bool]
+	RoleCapabilities   collections.Map[[]byte, bool]
 	UserRoles          collections.Map[collections.Pair[[]byte, uint64], bool]
 
 	addressCodec      address.Codec
@@ -89,7 +89,7 @@ func NewKeeper(
 		EntitlementsOwner:  collections.NewItem(builder, entitlements.OwnerKey, "entitlements_owner", collections.StringValue),
 		Paused:             collections.NewItem(builder, entitlements.PausedKey, "entitlements_paused", collections.BoolValue),
 		PublicCapabilities: collections.NewMap(builder, entitlements.PublicPrefix, "entitlements_public_capabilities", collections.StringKey, collections.BoolValue),
-		RoleCapabilities:   collections.NewMap(builder, entitlements.CapabilityPrefix, "entitlements_role_capabilities", collections.PairKeyCodec(collections.StringKey, collections.Uint64Key), collections.BoolValue),
+		RoleCapabilities:   collections.NewMap(builder, entitlements.CapabilityPrefix, "entitlements_role_capabilities", collections.BytesKey, collections.BoolValue),
 		UserRoles:          collections.NewMap(builder, entitlements.UserPrefix, "entitlements_user_roles", collections.PairKeyCodec(collections.BytesKey, collections.Uint64Key), collections.BoolValue),
 
 		accountKeeper:     accountKeeper,

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -47,7 +47,7 @@ type Keeper struct {
 	Paused             collections.Item[bool]
 	PublicCapabilities collections.Map[string, bool]
 	RoleCapabilities   collections.Map[[]byte, bool]
-	UserRoles          collections.Map[collections.Pair[[]byte, uint64], bool]
+	UserRoles          collections.Map[[]byte, bool]
 
 	addressCodec      address.Codec
 	accountKeeper     types.AccountKeeper
@@ -90,7 +90,7 @@ func NewKeeper(
 		Paused:             collections.NewItem(builder, entitlements.PausedKey, "entitlements_paused", collections.BoolValue),
 		PublicCapabilities: collections.NewMap(builder, entitlements.PublicPrefix, "entitlements_public_capabilities", collections.StringKey, collections.BoolValue),
 		RoleCapabilities:   collections.NewMap(builder, entitlements.CapabilityPrefix, "entitlements_role_capabilities", collections.BytesKey, collections.BoolValue),
-		UserRoles:          collections.NewMap(builder, entitlements.UserPrefix, "entitlements_user_roles", collections.PairKeyCodec(collections.BytesKey, collections.Uint64Key), collections.BoolValue),
+		UserRoles:          collections.NewMap(builder, entitlements.UserPrefix, "entitlements_user_roles", collections.BytesKey, collections.BoolValue),
 
 		accountKeeper:     accountKeeper,
 		bankKeeper:        bankKeeper,

--- a/keeper/msg_server_entitlements_test.go
+++ b/keeper/msg_server_entitlements_test.go
@@ -464,7 +464,7 @@ func TestEntitlementsUserCapability(t *testing.T) {
 	tmpRole := k.RoleCapabilities
 	k.RoleCapabilities = collections.NewMap(
 		collections.NewSchemaBuilder(mocks.FailingStore(mocks.Set, utils.GetKVStore(ctx, types.ModuleName))),
-		entitlements.CapabilityPrefix, "entitlements_role_capabilities", collections.PairKeyCodec(collections.StringKey, collections.Uint64Key), collections.BoolValue,
+		entitlements.CapabilityPrefix, "entitlements_role_capabilities", collections.BytesKey, collections.BoolValue,
 	)
 
 	// ACT: Attempt set role capability with failing RoleCapabilities collection store.

--- a/keeper/msg_server_entitlements_test.go
+++ b/keeper/msg_server_entitlements_test.go
@@ -319,7 +319,7 @@ func TestEntitlementsUserRoles(t *testing.T) {
 	tmp := k.UserRoles
 	k.UserRoles = collections.NewMap(
 		collections.NewSchemaBuilder(mocks.FailingStore(mocks.Set, utils.GetKVStore(ctx, types.ModuleName))),
-		entitlements.UserPrefix, "entitlements_user_roles", collections.PairKeyCodec(collections.BytesKey, collections.Uint64Key), collections.BoolValue,
+		entitlements.UserPrefix, "entitlements_user_roles", collections.BytesKey, collections.BoolValue,
 	)
 
 	// ACT: Attempt set user role with failing UserRoles collection store.

--- a/types/aggregator/keys.go
+++ b/types/aggregator/keys.go
@@ -6,19 +6,9 @@
 
 package aggregator
 
-import "encoding/binary"
-
-const SubmoduleName = "halo-aggregator"
-
 var (
 	OwnerKey       = []byte("aggregator/owner")
 	LastRoundIDKey = []byte("aggregator/last_round_id")
 	NextPriceKey   = []byte("aggregator/next_price")
 	RoundPrefix    = []byte("aggregator/round/")
 )
-
-func RoundKey(id uint64) []byte {
-	bz := make([]byte, 8)
-	binary.BigEndian.PutUint64(bz, id)
-	return append(RoundPrefix, bz...)
-}

--- a/types/entitlements/keys.go
+++ b/types/entitlements/keys.go
@@ -8,8 +8,6 @@ package entitlements
 
 import "encoding/binary"
 
-const SubmoduleName = "halo-entitlements"
-
 var (
 	OwnerKey         = []byte("entitlements/owner")
 	PausedKey        = []byte("entitlements/paused")
@@ -18,26 +16,8 @@ var (
 	UserPrefix       = []byte("entitlements/user/")
 )
 
-func PublicKey(method string) []byte {
-	return append(PublicPrefix, []byte(method)...)
-}
-
-func CapabilityKey(method string) []byte {
-	return append(CapabilityPrefix, []byte(method)...)
-}
-
 func CapabilityRoleKey(method string, role Role) []byte {
 	bz := make([]byte, 8)
 	binary.BigEndian.PutUint64(bz, uint64(role))
-	return append(CapabilityKey(method), bz...)
-}
-
-func UserKey(address []byte) []byte {
-	return append(UserPrefix, address...)
-}
-
-func UserRoleKey(address []byte, role Role) []byte {
-	bz := make([]byte, 8)
-	binary.BigEndian.PutUint64(bz, uint64(role))
-	return append(UserKey(address), bz...)
+	return append([]byte(method), bz...)
 }

--- a/types/entitlements/keys.go
+++ b/types/entitlements/keys.go
@@ -21,3 +21,9 @@ func CapabilityRoleKey(method string, role Role) []byte {
 	binary.BigEndian.PutUint64(bz, uint64(role))
 	return append([]byte(method), bz...)
 }
+
+func UserRoleKey(address []byte, role Role) []byte {
+	bz := make([]byte, 8)
+	binary.BigEndian.PutUint64(bz, uint64(role))
+	return append(address, bz...)
+}

--- a/types/keys.go
+++ b/types/keys.go
@@ -16,7 +16,3 @@ var (
 	OwnerKey    = []byte("owner")
 	NoncePrefix = []byte("nonce/")
 )
-
-func NonceKey(address []byte) []byte {
-	return append(NoncePrefix, address...)
-}


### PR DESCRIPTION
This PR addresses state compatibility issues when upgrading the Halo module from `v1` to `v2`

The underlying issue was that `collections.Pair` inserts an extra delimiter byte to distinguish between the two keys. However, with the manual state management included in v1, we simply concatenated the two keys together.

We've used the latest commit on this branch to patch a Noble testnet node, and can confirm it is working as expected:

![Screenshot 2024-10-29 at 09 32 25](https://github.com/user-attachments/assets/4b4656cf-b7fa-40e6-ac7c-ecbe8c56146e)
![Screenshot 2024-10-29 at 09 38 44](https://github.com/user-attachments/assets/bca73b3a-97c2-4aab-985c-7ccd9d51f454)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced role and capability management with simplified key structures for user roles and role capabilities.
  
- **Bug Fixes**
	- Improved error handling in test cases, ensuring accurate error messages for invalid operations.

- **Documentation**
	- Updated method signatures for clarity, particularly in role management functions.

- **Chores**
	- Removed unused constants and functions related to key generation, streamlining the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->